### PR TITLE
Retain read pairs with both mates mapped

### DIFF
--- a/make_alignment_VC_CNV.sh
+++ b/make_alignment_VC_CNV.sh
@@ -187,7 +187,7 @@ fi
      ${SAMSORT} ${bam} -T ${prefixsort} -o ${sortbam}
 
 # rmdup bam
-     ${SAMVIEW} -b -f 0x2 -q1 ${sortbam} | ${SAMRMDUP} - ${rmdupbam}
+     ${SAMVIEW} -b -F 0xC -q1 ${sortbam} | ${SAMRMDUP} - ${rmdupbam}
 
 # make bai
      ${SAMINDEX} ${rmdupbam} ${bai}


### PR DESCRIPTION
Instead of retaining proper pairs (according to the aligner) retain all read pairs with both mates mapped.
This is not exactly the same because bwa-mem flags pairs as *not* being properly mapped based on
insert size distribution.

It's something I learnt only recently, but this means that with -f 0x2 we are removing reads that may provide evidence for structural variation.

Of course, feel free to ignore this suggestion if you chose to filter based on insert size on purpose.