### PR TITLE
Add missing curl for curlgdrive

### DIFF
--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -32,7 +32,7 @@ apt-get update
 
 # packages that are required for installation
 apt-get install -y build-essential gcc-multilib libc-dev git-core cmake patch cmake ca-certificates \
-  autoconf wget zip unzip zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev \
+  autoconf wget curl zip unzip zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev \
   libncurses5-dev libxml2-dev \
   gfortran \
   default-jre \


### PR DESCRIPTION
The setup.sh downloads files from Google Drive using curl. A clean Debian 10 setup has curl not installed. So it might be a good idea to make sure that it's installed.