### PR TITLE
Add missing geneset_generation.R

### DIFF
--- a/databases/geneset_generation.R
+++ b/databases/geneset_generation.R
@@ -1,0 +1,7 @@
+library(GSA)
+gmt <- GSA.read.gmt('h.all.v7.0.entrez.gmt')
+genesets <- gmt$genesets
+names <- data.frame(Names = gmt$geneset.names, Descriptions = gmt$geneset.descriptions)
+names(genesets) <- names$Names
+hallmarksOfCancer <- genesets
+save(hallmarksOfCancer, file = "hallmarksOfCancer_GeneSets.RData")


### PR DESCRIPTION
During the database setup the `setup.sh` tries to execute `geneset_generation.sh`. That R script was moved from setup.sh to an additional file. It's contained in the docker repo but not in this one.