### PR TITLE
GSA package missing for geneset_generation.R

### DIFF
--- a/RScripts/install_packages.R
+++ b/RScripts/install_packages.R
@@ -12,6 +12,7 @@ install.packages("RColorBrewer")
 install.packages("circlize")
 install.packages("kableExtra")
 install.packages("knitr")
+install.packages("GSA")
 
 if (!requireNamespace("BiocManager", quietly = TRUE))
     install.packages("BiocManager")


### PR DESCRIPTION
`geneset_generation.R` uses the GSA package but it won't be installed using the setup script.