### PR TITLE
Make Picard use the specified tmp folder

### DIFF
--- a/programs.cfg.sh
+++ b/programs.cfg.sh
@@ -159,7 +159,7 @@ readonly BIN_BASE_RECALIBRATOR="${BIN_GATK} -T BaseRecalibrator -l INFO -R ${FIL
 readonly BIN_PRINT_READS="${BIN_GATK} -T PrintReads -R ${FILE_GENOME} -nct ${CFG_COMMON_CPUCORES} "
 
 # PICARD
-readonly BIN_FIX_MATE="java -Xmx${CFG_COMMON_MEMORY} -jar ${DIR_TOOLS}/picard/picard.jar FixMateInformation "
+readonly BIN_FIX_MATE="${BIN_JAVA} -Xmx${CFG_COMMON_MEMORY} -jar ${DIR_TOOLS}/picard/picard.jar FixMateInformation "
 
 # VARSCAN
 readonly BIN_VAR_SCAN="java -Xmx${CFG_COMMON_MEMORY} -jar ${DIR_TOOLS}/varscan/VarScan.jar"


### PR DESCRIPTION
Picard generates some tmp files for sorting. Those can get really huge, and in my case filled the whole parition as they get stored in the default tmp directory. 
I think it would be better to store them in the folder specified in the config. 

As BIN_JAVA already exists I used that. Another option would be the parameter `TMP_DIR`. Both of them work. 