### PR TITLE
fix: HGVSp spelling in txt2maf function

### DIFF
--- a/RScripts/filtering_tools.R
+++ b/RScripts/filtering_tools.R
@@ -1216,7 +1216,7 @@ txt2maf <- function(input, Center = center, refBuild = 'GRCh37', idCol = NULL, i
                                     Score = "",
                                     BAM_File = "",
                                     Sequencer = "",
-                                    HGSVp_Short = proteinChange,
+                                    HGVSp_Short = proteinChange,
                                     Amino_Acid_Change = proteinChange,
                                     TxChange = TxChange,
                                     Transcript_Id = Transcript_Id,


### PR DESCRIPTION
Usually, this makes no difference because `Amino_Acid_Change` will be used instead. Currently, I'm dealing with legacy files at our site that just have HGVSp, so cBioPortal was not very happy when trying to import...