### PR TITLE
Do not install recommended packages

### DIFF
--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -11,18 +11,7 @@ function install_java8()
   apt-get install -y --no-install-recommends apt-transport-https ca-certificates wget dirmngr gnupg software-properties-common && \
   wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - && \
   add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ && \
-  apt-get update && apt-get install adoptopenjdk-8-hotspot
-}
-
-function install_jdk8()
-{
-  ## install jre8
-   apt-get install -y --no-install-recommends apt-transport-https ca-certificates wget curl dirmngr gnupg software-properties-common && \
-   cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
-   echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list && \
-   apt-get update && apt-get -y install openjdk-8-jdk java8-runtime-headless ant && \
-   mv /etc/apt/sources.list.bak /etc/apt/sources.list && \
-   apt-get update
+  apt-get update && apt-get install -y --no-install-recommends adoptopenjdk-8-hotspot
 }
 
 function install_texlive()

--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -8,7 +8,7 @@ readonly DIR_SCRIPT=$(
 function install_java8()
 {
   ## install jre8
-  apt-get install -y apt-transport-https ca-certificates wget dirmngr gnupg software-properties-common && \
+  apt-get install -y --no-install-recommends apt-transport-https ca-certificates wget dirmngr gnupg software-properties-common && \
   wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - && \
   add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ && \
   apt-get update && apt-get install adoptopenjdk-8-hotspot
@@ -17,7 +17,7 @@ function install_java8()
 function install_jdk8()
 {
   ## install jre8
-   apt-get install -y apt-transport-https ca-certificates wget curl dirmngr gnupg software-properties-common && \
+   apt-get install -y --no-install-recommends apt-transport-https ca-certificates wget curl dirmngr gnupg software-properties-common && \
    cp /etc/apt/sources.list /etc/apt/sources.list.bak && \
    echo "deb http://ftp.de.debian.org/debian sid main" >> /etc/apt/sources.list && \
    apt-get update && apt-get -y install openjdk-8-jdk java8-runtime-headless ant && \
@@ -27,7 +27,7 @@ function install_jdk8()
 
 function install_texlive()
 {
-  apt-get install -y texlive texlive-lang-german texlive-latex-extra
+  apt-get install -y --no-install-recommends texlive texlive-lang-german texlive-latex-extra
   tlmgr option repository ftp://tug.org/historic/systems/texlive/2018/tlnet-final
   tlmgr install \
     breakurl \
@@ -45,14 +45,14 @@ function install_R()
   #apt-key adv --keyserver keyserver.ubuntu.com --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
   #wget -qO - https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xe19f5f87128899b192b1a2c2ad5f960a256a04af | apt-key add - &&
   apt-key add "/opt/MIRACUM-Pipe/debian/r_key.asc"
-  apt-get update && apt-get install -y -t buster-cran40 r-base-dev
+  apt-get update && apt-get install -y --no-install-recommends -t buster-cran40 r-base-dev
 }
 
 # update packages
 apt-get update
 
 # packages that are required for installation
-apt-get install -y build-essential gcc-multilib libc-dev git-core cmake patch cmake ca-certificates \
+apt-get install -y --no-install-recommends build-essential gcc-multilib libc-dev git-core cmake patch cmake ca-certificates \
   autoconf wget zip unzip zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev libmariadbclient-dev \
   libncurses5-dev libxml2-dev libcairo2-dev libxt-dev libgit2-dev \
   python python-dev python-numpy python-biopython python-xlrd python-openpyxl \


### PR DESCRIPTION
apt often tries to install additional packages as "recommends" such as unattended-upgrade. This in particular is not compatible with containerized environments like docker or singularity as they don't rely on systemd.
This can cause (and so did it for me) the installation to fail.

Also the JRE8 installation command was lacking a `-y` causing it to fail if it wasn't installed before as container builds are non-interactive.

In addition I removed the install JDK8 function as it is not used. 