### PR TITLE
Make bedtools intersect unique

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -295,5 +295,5 @@ reference:
     # target capture correlation factors for mutation signature analysis
     captureCorFactors : targetCapture_cor_factors.rda
     # covered exons by capture kit; basically intersection of exome with capture regions
-    # e.g. bedtools intersect -a targets.bed -b bed_exons_hg19.bed > exons_Routine.bed
+    # e.g. bedtools intersect -a targets.bed -b bed_exons_hg19.bed > exons_Routine.bed -u
     coveredExons: exons_5UTR.bed


### PR DESCRIPTION
You will want to avoid overlaps being reported in the resulting bedfile of a bedtools intersect.
Otherwise results will look like this:
- All Exons (UCSC): 96908652b
- Twist Core Exome: 33053262b
- Intersect without `-u`: 89632843b

Obviously your actual coverage can only go down when using this operation.

With `-u` (still TwistCoreExome):  32932521b

Ref: https://bedtools.readthedocs.io/en/latest/content/tools/intersect.html
