### PR TITLE
Increase timeout when downloading R packages

### DIFF
--- a/RScripts/install_packages.R
+++ b/RScripts/install_packages.R
@@ -5,7 +5,7 @@
 # Extended by: Patrick Metzger
 # Extended on: 14.05.2020
 
-options(repos=structure(c(CRAN="http://cloud.r-project.org")))
+options(repos=structure(c(CRAN="http://cloud.r-project.org")), timeout = 600)
 
 if (!requireNamespace("BiocManager", quietly = TRUE))
     install.packages("BiocManager")


### PR DESCRIPTION
By default the timeout when downloading the R packages is 60s. As some packages are quite huge (~700MB) it's possible to run into a timeout when installing / building with a slower internet connection. My proposal would be to increase the timeout to 10m.