### PR TITLE
Fix quality check function

### DIFF
--- a/RScripts/stats_tools.R
+++ b/RScripts/stats_tools.R
@@ -226,9 +226,9 @@ quality_check <- function(path, nsamples, protocol){
       fastq_data <- read.table(file = filename, skip = 2 , nrows = 7, sep = "\t")
       gc_content[i] <- as.character(fastq_data[which(fastq_data$V1 == "%GC"), 2])
       fastq_data <- read.table(file = filename, skip = 12 , nrows = sectionEndings[2]-14, sep = "\t")
-      sum_QC <- 2 * sum(fastq_data$V2[grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)]) + 
-                sum(fastq_data$V2[-grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)])
-      mean_QC[i] <- sum_QC/as.integer(as.character(fastq_data$V1[dim(fastq_data)[1]]))
+      readlength <- convert_readlength(fastq_data$V1)
+      sum_QC <- sum(readlength * fastq_data$V2)
+      mean_QC[i] <- sum_QC/sum(readlength)
     }
     if (protocol == "panelTumor") {
       filename <- paste0(path, "/", nsamples[i], "_output.sort.realigned.fixed.recal_fastqc/fastqc_data.txt")
@@ -236,10 +236,18 @@ quality_check <- function(path, nsamples, protocol){
       fastq_data <- read.table(file = filename, skip = 2 , nrows = 7, sep = "\t")
       gc_content[i] <- as.character(fastq_data[which(fastq_data$V1 == "%GC"), 2])
       fastq_data <- read.table(file = filename, skip = 12 , nrows = sectionEndings[2]-14, sep = "\t")
-      sum_QC <- 2 * sum(fastq_data$V2[grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)]) + 
-                sum(fastq_data$V2[-grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)])
-      mean_QC[i] <- sum_QC/as.integer(as.character(fastq_data$V1[dim(fastq_data)[1]]))
+      readlength <- convert_readlength(fastq_data$V1)
+      sum_QC <- sum(readlength * fastq_data$V2)
+      mean_QC[i] <- sum_QC/sum(readlength)
     }
   }
- return(list(labs = nsamples, gc_content = gc_content, mean_QC = mean_QC)) 
+  return(list(labs = nsamples, gc_content = gc_content, mean_QC = mean_QC)) 
+}
+
+convert_readlength <- function(x) {
+  split <- str_split(x, "-", simplify = T)
+  start <- as.numeric(split[,1])
+  end <- as.numeric(split[,2])
+  end[is.na(end)] = start[is.na(end)]
+  return((end-start)+1)
 }

--- a/RScripts/stats_tools.R
+++ b/RScripts/stats_tools.R
@@ -221,29 +221,21 @@ quality_check <- function(path, nsamples, protocol){
   mean_QC <- rep(0, times = length(nsamples))
   for (i in 1:length(nsamples)){
     if (protocol %in% c("somatic", "somaticGermline", "tumorOnly")){
-      fastq_data <- read.table(file = paste0(path, "/", nsamples[i],
-                                            "_output.sort.filtered.rmdup.realigned.fixed.recal_fastqc/fastqc_data.txt"),
-                              skip = 2 , nrows = 7, sep = "\t")
+      filename <- paste0(path, "/", nsamples[i], "_output.sort.filtered.rmdup.realigned.fixed.recal_fastqc/fastqc_data.txt")
+      sectionEndings <- which(str_detect(readLines(file(filename, "r", blocking = F)), ">>END_MODULE") == TRUE)
+      fastq_data <- read.table(file = filename, skip = 2 , nrows = 7, sep = "\t")
       gc_content[i] <- as.character(fastq_data[which(fastq_data$V1 == "%GC"), 2])
-      readlength <- as.numeric(strsplit(as.character(fastq_data[which(fastq_data$V1 == "Sequence length"), 2]), split = "-")[[1]][2])
-      rows2read <- 10+(readlength-10)/2
-      fastq_data <- read.table(file = paste0(path, "/", nsamples[i],
-                                            "_output.sort.filtered.rmdup.realigned.fixed.recal_fastqc/fastqc_data.txt"),
-                              skip = 12 , nrows = rows2read, sep = "\t")
+      fastq_data <- read.table(file = filename, skip = 12 , nrows = sectionEndings[2]-14, sep = "\t")
       sum_QC <- 2 * sum(fastq_data$V2[grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)]) + 
                 sum(fastq_data$V2[-grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)])
       mean_QC[i] <- sum_QC/as.integer(as.character(fastq_data$V1[dim(fastq_data)[1]]))
     }
     if (protocol == "panelTumor") {
-      fastq_data <- read.table(file = paste0(path, "/", nsamples[i],
-                                            "_output.sort.realigned.fixed.recal_fastqc/fastqc_data.txt"),
-                              skip = 2 , nrows = 7, sep = "\t")
+      filename <- paste0(path, "/", nsamples[i], "_output.sort.realigned.fixed.recal_fastqc/fastqc_data.txt")
+      sectionEndings <- which(str_detect(readLines(file(filename, "r", blocking = F)), ">>END_MODULE") == TRUE)
+      fastq_data <- read.table(file = filename, skip = 2 , nrows = 7, sep = "\t")
       gc_content[i] <- as.character(fastq_data[which(fastq_data$V1 == "%GC"), 2])
-      readlength <- as.numeric(strsplit(as.character(fastq_data[which(fastq_data$V1 == "Sequence length"), 2]), split = "-")[[1]][2])
-      rows2read <- 10+(readlength-10)/2
-      fastq_data <- read.table(file = paste0(path, "/", nsamples[i],
-                                            "_output.sort.realigned.fixed.recal_fastqc/fastqc_data.txt"),
-                              skip = 12 , nrows = rows2read, sep = "\t")
+      fastq_data <- read.table(file = filename, skip = 12 , nrows = sectionEndings[2]-14, sep = "\t")
       sum_QC <- 2 * sum(fastq_data$V2[grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)]) + 
                 sum(fastq_data$V2[-grep(x = fastq_data$V1, pattern = "-", fixed = TRUE)])
       mean_QC[i] <- sum_QC/as.integer(as.character(fastq_data$V1[dim(fastq_data)[1]]))


### PR DESCRIPTION
This PR fixes the `quality_check` function for various inputs by changing following things:

1. Identifying the ends of each module using the `>>END_MODULE` line. The required amount of lines that need to be read can be determined from that point.
2. Using variable weights on the on the readlength lines. This is done by converting the first column e.g. `145-148` into its interval length 4 and using this as a factor.