### PR TITLE
Export CNVs into GISTIC format for cBioPortal

### DIFF
--- a/RScripts/Main.R
+++ b/RScripts/Main.R
@@ -277,6 +277,7 @@ if (protocol == "somaticGermline" | protocol == "somatic"){
   ## Input/Output Files
   ratio_file <- paste0(path_input, "CNV/", sample, "_td_output.sort.filtered.rmdup.realigned.fixed.recal.bam_ratio.txt")
   cnvs_file <- paste0(path_input, "CNV/", sample, "_td_output.sort.filtered.rmdup.realigned.fixed.recal.bam_CNVs")
+  cpn_file <- paste0(path_input, "CNV/", sample, "_td_output.sort.filtered.rmdup.realigned.fixed.recal.bam_sample.cpn")
 
   # Results
   cnv_pvalue_txt <- paste0(cnvs_file, ".p.value.txt")
@@ -289,6 +290,7 @@ if (protocol == "somaticGermline" | protocol == "somatic"){
   # outfile_gain <- paste0(path_output, sample, "_CNV_gain3_GO.xlsx")
   # outfile_dna_damage <- paste0(path_output, sample, "_CNV_dna_damage.xlsx")
   outfile_cnvs_cbioportal <- paste0(path_output, sample, "_CNV_cbioportal.txt")
+  outfile_cnvs_seg <- paste0(path_output, sample, "_CNV.seg")
 
   #   cnv_analysis_results <- cnv_analysis(ratio_file = ratio_file, cnvs_file = cnvs_file, cnv_pvalue_txt = cnv_pvalue_txt,
   #                                      outfile_plot = cnv_plot,
@@ -306,12 +308,16 @@ if (protocol == "somaticGermline" | protocol == "somatic"){
   #                                      id = id,
   #                                      protocol = protocol)
 
-  cnv_analysis_results <- cnv_analysis(ratio_file = ratio_file, cnvs_file = cnvs_file, cnv_pvalue_txt = cnv_pvalue_txt,
+  cnv_analysis_results <- cnv_analysis(ratio_file = ratio_file,
+                                       cnvs_file = cnvs_file,
+                                       cpn_file = cpn_file,
+                                       cnv_pvalue_txt = cnv_pvalue_txt,
                                        outfile_ideogram = cnv_ideogram_plot,
                                        path_data = path_data,
                                        path_script = path_script,
                                        targets_txt = targets_txt,
                                        outfile_cbioportal = outfile_cnvs_cbioportal,
+                                       outfile_seg = outfile_cnvs_seg,
                                        id = id,
                                        protocol = protocol)
 }
@@ -320,18 +326,24 @@ if (protocol == "tumorOnly"){
   ## Input/Output Files
   ratio_file <- paste0(path_input, "CNV/", sample, "_td_output.sort.rmdup.realigned.fixed.recal.bam_ratio.txt")
   cnvs_file <- paste0(path_input, "CNV/", sample, "_td_output.sort.rmdup.realigned.fixed.recal.bam_CNVs")
+  cpn_file <- paste0(path_input, "CNV/", sample, "_td_output.sort.rmdup.realigned.fixed.recal.bam_sample.cpn")
 
   # Results
   cnv_pvalue_txt <- paste0(cnvs_file, ".p.value.txt")
   cnv_ideogram_plot <- paste0(path_output, sample,"_CNV_Plot_Ideogram.pdf")
   outfile_cnvs_cbioportal <- paste0(path_output, sample, "_CNV_cbioportal.txt")
+  outfile_cnvs_seg <- paste0(path_output, sample, "_CNV.seg")
 
-  cnv_analysis_results <- cnv_analysis(ratio_file = ratio_file, cnvs_file = cnvs_file, cnv_pvalue_txt = cnv_pvalue_txt,
+  cnv_analysis_results <- cnv_analysis(ratio_file = ratio_file,
+                                       cnvs_file = cnvs_file,
+                                       cpn_file = cpn_file,
+                                       cnv_pvalue_txt = cnv_pvalue_txt,
                                        outfile_ideogram = cnv_ideogram_plot,
                                        path_data = path_data,
                                        path_script = path_script,
                                        targets_txt = targets_txt,
                                        outfile_cbioportal = outfile_cnvs_cbioportal,
+                                       outfile_seg = outfile_cnvs_seg,
                                        id = id,
                                        protocol = protocol)
 }

--- a/RScripts/cnv_ana_tools.R
+++ b/RScripts/cnv_ana_tools.R
@@ -479,6 +479,32 @@ cnvs2cbioportal <- function(cnvs, id, outfile_cbioportal){
   write.table(x = cnvs.out, file = outfile_cbioportal, quote = F, sep = "\t", col.names = T, row.names = F)
 }
 
+freec2seg <- function(cnvs_file, cpn_file, id, outfile_seg){
+  #' Export annotated CNVs to a seg file
+  #' 
+  #' @describtion Export annotated CNVs to a seg file compliant to the GISTIC syntax
+  #' 
+  #' @param cnvs_file string. Filename for CNVs
+  #' @param cpn_file string. Filename for CPN
+  #' @param id string. Sample ID
+  #' @param outfile_seg string. Name of the outputfile
+
+  bam <- read.table(cnvs_file, header = F)
+  cpn <- read.table(cpn_file, header = F)
+  bam$V4 <- log2(bam$V4) - 1
+  bam$V5 <- paste(id,"TD",sep = "_")
+  bam$V6 <- 0
+  bam <- bam[c(5,1:3,6,4)]
+  colnames(bam) <- c("ID", "chrom", "loc.start", "loc.end", "num.mark", "seg.mean")
+
+  for (i in 1:nrow(bam)) {
+    entry <- bam[i,]
+    bam[i,]$num.mark <- sum(cpn[cpn$V1 == entry$chrom & (cpn$V2 >= entry$loc.end & cpn$V2 <= entry$loc.end | cpn$V3 >= entry$loc.start & cpn$V3 <= entry$loc.end),]$V4)
+  }
+
+  write.table(bam, outfile_seg, sep='\t', quote = F, row.names = F)
+}
+
 # TODO
 cnv_panel <- function(input_file, outfile, outfile_ts_og, outfile_ideogram, path_data, sureselect, targets_txt, protocol) {
   #' CNV Analysis for Tumor-Only Data

--- a/RScripts/cnv_analysis.R
+++ b/RScripts/cnv_analysis.R
@@ -82,18 +82,24 @@
 #        = cnv_analysis_results, out = out, impa = impa))
 # }
 
-cnv_analysis <- function(ratio_file, cnvs_file, cnv_pvalue_txt,
-                         outfile_ideogram, path_data, path_script, targets_txt, id, outfile_cbioportal, protocol){
+cnv_analysis <- function(ratio_file, cnvs_file, cpn_file, cnv_pvalue_txt, outfile_ideogram, path_data,
+                         path_script, targets_txt, id, outfile_cbioportal, outfile_seg, protocol){
 #' CNV Analysis
 #'
 #' @description Analyse the
 #'
 #' @param ratio_file string. Filename for ratio
 #' @param cnvs_file string. Filename for CNVs
+#' @param cpn_file string. Filename for CPN
 #' @param cnv_pvalue_txt string. Filename of CNV regions file
 #' @param outfile_ideogram string. Filename of ideogram
 #' @param path_data string. Directory of the databases
 #' @param path_script string. Directory of required scripts
+#' @param targets_txt string. Path of the targets.txt file provided by the Capture Kit manufracturer
+#' @param id string. Sample ID
+#' @param outfile_cbioportal string. Name of the outputfile
+#' @param outfile_seg string. Name of the outputfile
+#' @param protocol string. Type of protocol used for analyses
 #' 
 #' @return returns list of
 #' @return cnvs_annotated dataframe. Table of annotated CNVs
@@ -142,6 +148,8 @@ cnv_analysis <- function(ratio_file, cnvs_file, cnv_pvalue_txt,
   impa <- list(ddr = ddr, pam = pam, rme = rme, tyk = tyk, cec = cec)
   
   cnvs2cbioportal(out, id, outfile_cbioportal)
+
+  freec2seg(cnvs_file, cpn_file, id, outfile_seg)
 
   return(list(cnvs_annotated = cnvs_annotated, cnv_analysis_results
        = cnv_analysis_results, out = out, impa = impa))


### PR DESCRIPTION
This PR adds a function that exports the CNV data into the GISTIC format which can directly be imported into cBioPortal.

This enables the CNV Segments tab in the study centric view and also enables the CNA line in the patient centric view as shown here: 
![image](https://user-images.githubusercontent.com/20756025/114703205-47453200-9d25-11eb-8f6c-8c03b8c070dc.png)

In addition to that I extended the roxygen headers of the functions I touched to match the actual signature.

Also see the attached files that will be produced for Patient_example:
[somaticGermline_Patient_example_CNV.seg.txt](https://github.com/AG-Boerries/MIRACUM-Pipe/files/6310509/somaticGermline_Patient_example_CNV.seg.txt)
[meta_cna_seg.txt](https://github.com/AG-Boerries/MIRACUM-Pipe/files/6310507/meta_cna_seg.txt)



