### PR TITLE
Fix -inf values in seg file

### DIFF
--- a/RScripts/cnv_ana_tools.R
+++ b/RScripts/cnv_ana_tools.R
@@ -501,6 +501,8 @@ freec2seg <- function(cnvs_file, cpn_file, id, outfile_seg){
     entry <- bam[i,]
     bam[i,]$num.mark <- sum(cpn[cpn$V1 == entry$chrom & (cpn$V2 >= entry$loc.end & cpn$V2 <= entry$loc.end | cpn$V3 >= entry$loc.start & cpn$V3 <= entry$loc.end),]$V4)
   }
+  
+  bam$seg.mean[!is.finite(bam$seg.mean)] <- -1
 
   write.table(bam, outfile_seg, sep='\t', quote = F, row.names = F)
 }


### PR DESCRIPTION
Currently some seg files contain -inf as the result of a logarithmic operation. This is not a valid value and should be replaced with -1.