### PR TITLE
Add proper parser for samtools stats

### DIFF
--- a/RScripts/stats.R
+++ b/RScripts/stats.R
@@ -1,5 +1,5 @@
 stats <- function(path = path2coverage, outfile_pdf = coverage_out, stats_td,
-      stats_gd, path_output, protocol){
+      stats_gd = NULL, path_output, protocol){
   #' Statistics
   #'
   #' @description Information about Coverage and Readdepth
@@ -18,11 +18,7 @@ stats <- function(path = path2coverage, outfile_pdf = coverage_out, stats_td,
   #' @details Statistical numbers are extracted from alignment's statistics.
   cover <- coverage_plot(path = path, outfilePDF = coverage_out, protocol = protocol)
   cover_exons <- coverage_exon(path = path, protocol = protocol)
-  if (protocol == "somaticGermline" | protocol == "somatic"){
-    avreads <- reads(stats_td, stats_gd)
-  } else {
-    avreads <- treads(stats_td)
-  }
+  avreads <- reads(stats_td, stats_gd)
   qc_check <- quality_check(path = path, nsamples = cover$labs, protocol = protocol)
   #return(list(cover = cover, avreads = avreads))
   return(list(cover = cover, cover_exons = cover_exons, avreads = avreads, qc_check = qc_check))

--- a/RScripts/stats_tools.R
+++ b/RScripts/stats_tools.R
@@ -121,7 +121,7 @@ if (protocol != "panelTumor"){
   return(list(cov = cov, perc = perc, labs = labs, files = files))
 }
 
-reads <- function(tfile, gfile){
+reads <- function(tfile, gfile = NULL){
   #' Reads
   #'
   #' @description Extract the mean readcount
@@ -136,38 +136,24 @@ reads <- function(tfile, gfile){
   #' 
   #' @details The statistics files contain information about properly paired
   #' @details reads. The information is extracted for the report.
-  treads_tab <- read.table(file = tfile, sep = "\t", skip = 7, nrows = 38, fill = TRUE)
-  id <- which (as.character(treads_tab$V2) == "reads properly paired:")
-  treads <- as.character(treads_tab$V3[id])
-  treads <- as.numeric(treads)/1000000
-  ntreads <- round(treads)
-  tin_size <- as.character(treads_tab$V3[which(as.character(treads_tab$V2) == "insert size average:")])
-  tin_sd <- as.character(treads_tab$V3[which(as.character(treads_tab$V2) == "insert size standard deviation:")])
+  treads_tab <- readSamtoolsStats(tfile, "SN")$SN
+  ntreads <- round(as.numeric(treads_tab$value[which(as.character(treads_tab$description) == "reads properly paired:")])/1000000)
+  tin_size <- as.character(treads_tab$value[which(as.character(treads_tab$description) == "insert size average:")])
+  tin_sd <- as.character(treads_tab$value[which(as.character(treads_tab$description) == "insert size standard deviation:")])
 
-  greads_tab <- read.table(file = gfile, sep = "\t", skip = 7, nrows = 38, fill = TRUE)
-  id <- which (as.character(greads_tab$V2) == "reads properly paired:")
-  greads <- as.character(greads_tab$V3[id])
-  greads <- as.numeric(greads)/1000000
-  ngreads <- round(greads)
-  gin_size <- as.character(greads_tab$V3[which(as.character(greads_tab$V2) == "insert size average:")])
-  gin_sd <- as.character(greads_tab$V3[which(as.character(greads_tab$V2) == "insert size standard deviation:")])
+  ngreads <- NULL
+  gin_size <- NULL
+  gin_sd <- NULL
   
+  if (!is.null(gfile)) {
+    greads_tab <- readSamtoolsStats(gfile, "SN")$SN
+    ngreads <- round(as.numeric(treads_tab$value[which(as.character(treads_tab$description) == "reads properly paired:")])/1000000)
+    gin_size <- as.character(treads_tab$value[which(as.character(treads_tab$description) == "insert size average:")])
+    gin_sd <- as.character(treads_tab$value[which(as.character(treads_tab$description) == "insert size standard deviation:")])
+  }
   
   return(list(nRT = ntreads, tin = tin_size, tin_sd = tin_sd,
               nRG = ngreads, gin = gin_size, gin_sd = gin_sd))
-}
-
-treads <- function(tfile){
-  treads_tab <- read.table(file = tfile, sep = "\t", skip = 7, nrows = 31, fill = TRUE)
-  id <- which (as.character(treads_tab$V2) == "reads properly paired:")
-  treads <- as.character(treads_tab$V3[id])
-  treads <- as.numeric(treads)/1000000
-  ntreads <- round(treads)
-  tin_size <- as.character(treads_tab$V3[which(as.character(treads_tab$V2) == "insert size average:")])
-  tin_sd <- as.character(treads_tab$V3[which(as.character(treads_tab$V2) == "insert size standard deviation:")])
-  
-  return(list(nRT = ntreads, tin = tin_size, tin_sd = tin_sd,
-              nRG = NULL, gin = NULL, gin_sd = NULL))
 }
 
 coverage_exon <- function(path, protocol = protocol){
@@ -246,4 +232,136 @@ convert_readlength <- function(x) {
   end <- as.numeric(split[,2])
   end[is.na(end)] = start[is.na(end)]
   return((end-start)+1)
+}
+
+#' Parse samtools stat output
+#' Source: https://github.com/mcjmigdal/sumsamstats/blob/master/R/parse.R
+#'
+#' readSamtoolsStats parses output of samtools stat making it easy to
+#' work with it in R.
+#'
+#' @param file the name of the file which the data are to be read from. File must be
+#' of type \code{character}, providing path to input file. If it does not provide an
+#' absolute path(s), the file name is relative to the current working directory, \code{getwd()}.
+#'
+#' @param section A character vector of patterns to extract from the report. Each section of samtools stats report is uniquley
+#' labeled, for example Summary Numbers are labeled as SN. By default all sections are read.
+#'
+#' @return list of data frames holding data from different parts of \code{samtools stat} output.
+#' Sections names are: SN (summary numbers), FFQ (first fragment qualities), LFQ (last fragment qualities),
+#' GCF (GC Content of first fragments), GCL (GC content of last fragments), GCC (ACGT content per cycle),
+#' IS (insert size), RL (read lengths), ID (indel distribution), IC (indels per cycle), COV (coverage distribution),
+#' GCD (GC-depth)
+#'
+#' @examples
+#' readSamtoolsStats(file = system.file('extdata', 'sample1', package = 'sumsamstats'))
+#'
+#' @export
+readSamtoolsStats <- function(file, section = c("SN", "FFQ", "LFQ", "GCF", "GCL", "GCC", "IS", "RL", "ID", "IC", "COV", "GCD")) {
+    if (!is.character(file)) {
+        stop("File argument must be of class character!\n")
+    }
+    if (!file.exists(file)) {
+        stop(paste0("File '", file, "' doesn't exists!\n"))
+    }
+    if (all(!section %in% c("SN", "FFQ", "LFQ", "GCF", "GCL", "GCC", "IS", "RL", "ID", "IC", "COV", "GCD"))) {
+        stop(paste0("Parsing '", section, "' is not supported!"))
+    }
+
+    grepTable <- list(
+      SN = list(
+        columns = c(2, 3),
+        col.names = c("description", "value")
+        ),
+      FFQ = list(
+        columns = 2:43,
+        col.names = c("cycle", paste0("Qual", 1:41))
+        ),
+      LFQ = list(
+        columns = 2:43,
+        col.names = c("cycle", paste0("Qual", 1:41))
+        ),
+      GCF = list(
+        columns = c(2, 3),
+        col.names = c("GC", "count")
+        ),
+      GCL = list(
+        columns = c(2, 3),
+        col.names = c("GC", "count")
+        ),
+      GCC = list(
+        columns = 2:8,
+        col.names = c("cycle", "A", "C", "G", "T", "N", "O")
+        ),
+      IS = list(
+        columns = c(2, 3),
+        col.names = c("insert_size", "pairs_total")
+        ),
+      RL = list(
+        columns = c(2, 3),
+        col.names = c("read_length", "count")
+        ),
+      ID = list(
+        columns = c(2, 3, 4),
+        col.names = c("length", "number_of_insertions", "number_of_deletions")
+        ),
+      IC = list(
+        columns = c(2, 3, 4, 5, 6),
+        col.names = c("cycle", "number_of_insertions_fwd", "number_of_insertions_rwd",
+                      "number_of_deletions_fwd", "number_of_deletions_rwd")
+        ),
+      COV = list(
+        columns = c(3, 4),
+        col.names = c("coverage", "bases")
+        ),
+      GCD = list(
+        columns = c(2, 3, 4, 5, 6, 7, 8),
+        col.names = c("GC", "unique_sequence_percentiles", "10th", "25th", "50th", "75th", "90th")
+        )
+      )
+
+    stats <- list()
+    inputFile <- readLines(file)
+    for (i in 1:length(section)) {
+        stats[[section[i]]] <- .grepData(inputFile, section[i], columns = grepTable[[section[i]]]$columns, col.names = grepTable[[section[i]]]$col.names)
+    }
+    return(stats)
+}
+
+#' Helper function for parsing output of samtools stats
+#' Source: https://github.com/mcjmigdal/sumsamstats/blob/master/R/parse.R
+#'
+#' As readSamtoolsStats parses output of samtools stat this function is used to grep relevant
+#' parts of the output.
+#'
+#' @param input A character vector containing output of samtools stats, each line as one element.
+#'
+#' @param columns A integer vector containing numbers of columns to extract from specified section of samtools
+#' stats report.
+#'
+#' @param section Pattern to extract from the report. Each section of samtools stats report is uniquley
+#' labeled, for example Summary Numbers are labeled as SN.
+#'
+#' @param col.names A character vector containing names of extracted columns. Optional.
+#'
+#' @return data frame holding data from selected section of \code{samtools stat} output.
+#'
+#' @examples
+#' file <- system.file('extdata', 'sample1', package = 'sumsamstats')
+#' inputFile <- readLines(file)
+#' .grepData(input=inputFile, section='SN', columns=c(2,3), col.names=c('description', 'value'))
+#'
+.grepData <- function(input, section, columns, col.names = "") {
+  section <- paste("^", section, sep = "")
+  handle <- strsplit(input[grep(pattern = section, input)], split = "\t")
+  if (length(handle) == 0) {
+    stop("Could not find pattern '", section, "'!")
+  }
+  handle <- data.frame(vapply(columns, function(i) {
+    vapply(handle, `[`, i, FUN.VALUE = character(1))
+  }, FUN.VALUE = character(length(handle))), stringsAsFactors = FALSE)
+  if (length(col.names > 0)) {
+    colnames(handle) <- col.names
+  }
+  return(handle)
 }


### PR DESCRIPTION
The output of `samtools stats` differs, depending on the type of input data. Therefore the report generation of the `tumorOnly` protocol always failed because the stats file had a different amount of rows in the `SN` section.

However, there is a parser for such stats files available that handles the task flawlessly and offers direct access to specific lines of a section. When integrating this parser I also unified the codebase of this section.