### PR TITLE
fix actionable genes

### DIFF
--- a/RScripts/Main.R
+++ b/RScripts/Main.R
@@ -58,7 +58,7 @@ target_capture_cor_factors <- args[20]
 vaf <- as.numeric(args[21])*100
 min_var_count <- as.numeric(args[22])
 maf_cutoff <- as.numeric(args[23])
-actionable_genes <- args[24]
+actionable_genes <- ifelse(args[24]=="/opt/MIRACUM-Pipe/databases/", NA, args[24])
 covered_exons <- args[25]
 entity <- as.character(args[26])
 gender <- as.character(args[27])
@@ -369,7 +369,7 @@ if (protocol == "somatic" | protocol == "somaticGermline") {
       vaf = vaf,
       min_var_count = min_var_count,
       maf = maf_cutoff,
-      actionable_genes = NA,
+      actionable_genes = actionable_genes,
       covered_exons = covered_exons,
       cov_t = stats$cover_exons$perc[[1]][1],
       sureselect_type = sureselect_type

--- a/RScripts/Report.Rnw
+++ b/RScripts/Report.Rnw
@@ -134,7 +134,7 @@ Bei den \textbf{Gensymbolen} ist ein Link zu \textbf{\textit{Genome Nexus}} hint
 
 Im Anhang befinden sich Tabellen zu allen detektierten somatischen, LoH und Keimbahnmutationen (Kap \ref{all_som_mut}, \ifthenelse{\equal{\detokenize{\Sexpr{protocol}}}{\detokenize{somaticGermline}}}{\ref{all_loh}}{}, \ref{all_germline}). Es werden allerdings nur seltene, exonische Mutationen mit einer VAF über \Sexpr{vaf} \% gelistet.
 
-\ifthenelse{\equal{\detokenize{\Sexpr{nchar(actionable_genes) > 0}}}{\detokenize{TRUE}}}{Die Keimbahnmutationen sind gemäß der Empfehlungen des American College of Medical Genetics für Zusatzbefunde bei Exom- und Genom-Untersuchungen (ACMG SF v3.0, PubMed 34012068) gefiltert, sodass nur Gene berichtet werden, aus deren Veränderung sich gezielt therapeutische oder präventive Maßnahmen ableiten lassen.}{}
+\ifthenelse{\equal{\detokenize{\Sexpr{!is.na(actionable_genes)}}}{\detokenize{TRUE}}}{Die Keimbahnmutationen sind gemäß der Empfehlungen des American College of Medical Genetics für Zusatzbefunde bei Exom- und Genom-Untersuchungen (ACMG SF v3.0, PubMed 34012068) gefiltert, sodass nur Gene berichtet werden, aus deren Veränderung sich gezielt therapeutische oder präventive Maßnahmen ableiten lassen.}{}
 
 <<som_mut_cg, eval=TRUE, results="tex", echo=FALSE>>=
 #if (dim(sum_mut_cg$muts_tab)[1] == 0) {

--- a/RScripts/filtering.R
+++ b/RScripts/filtering.R
@@ -252,6 +252,15 @@ filtering <- function(
       snv_vcf = snpefffile_snp,
       indel_vcf = snpefffile_indel
     )
+    write.table(
+      x = out.maf,
+      file = outfile_maf,
+      append = F,
+      quote = F,
+      sep = "\t",
+      col.names = T,
+      row.names = F
+    )
 
     return(
       list(
@@ -267,7 +276,7 @@ filtering <- function(
 
   } else if (mode == "N" | mode == "T") {
     print("No SNVs passed filter!")
-    out.maf <- NULL
+    out.maf <- data.frame()
     msi <- NULL
     return(
       list(
@@ -283,7 +292,7 @@ filtering <- function(
 
   } else if (mode == "LOH") {
     print("No LOH passed filter!")
-    out.maf <- NULL
+    out.maf <- data.frame()
     return(
       list(
         table = x,
@@ -511,7 +520,7 @@ filtering_mutect2 <- function(
       input = x,
       protocol = protocol,
       snv_vcf = snpefffile,
-      Center = 'Freiburg',
+      Center = center,
       refBuild = 'hg19',
       id = sample,
       sep = "\t",
@@ -542,8 +551,8 @@ filtering_mutect2 <- function(
 
   } else if (mode == "N" | mode == "T") {
     print("No SNVs passed filter!")
-    out.maf <- NULL
-    return(
+    out.maf <- data.frame()
+   return(
       list(
         table = x,
         tmb = tmb$tmb,
@@ -557,7 +566,7 @@ filtering_mutect2 <- function(
 
   } else if (mode == "LOH") {
     print("No LOH passed filter!")
-    out.maf <- NULL
+    out.maf <- data.frame()
     return(
       list(
         table = x,

--- a/RScripts/filtering_tools.R
+++ b/RScripts/filtering_tools.R
@@ -216,7 +216,7 @@ mrc <- function(x, min_var_count){
 }
 
 actionable <- function(x, actionable_genes) {
-  if(is.na(actionable_genes) | actionable_genes == "" ) {
+  if(is.na(actionable_genes)) {
     return(x)
   }
   genes <- read.table(actionable_genes, header = F)


### PR DESCRIPTION
The actionable_genes feature was disabled/broken in the beta_test.
With this PR the functionality is restored: If the parameter is commented out (default), all germline mutations will be reported. If the parameter in the config is set, only the variants listed in the text file will be reported and the notice/explanatio will be added to the pdf report.