### PR TITLE
fix empty pathway dataframe

### DIFF
--- a/RScripts/Report_tools.R
+++ b/RScripts/Report_tools.R
@@ -1278,8 +1278,8 @@ pthws_mut <- function(df, protocol) {
   if (length(id_to) != 0) {
     df <- df[-c(id_to:dim(df)[1]), ]
   }
-  if (class(df) == "list" | is.null(df)) {
-    if (is.null(df)) {
+  if (nrow(df) == 0 | class(df) == "list" | is.null(df)) {
+    if (nrow(df) == 0 | is.null(df)) {
       return(NULL)
     } else if (sum(lapply(df, function(x){return(dim(x)[1])})) == 0){
       return(NULL)


### PR DESCRIPTION
I just ran into a case where there was a Topart item in the dataframe which was removed by the lines 1278-1280. After that the script ran into an issue because the detection that the list was now empty was not successful.