### PR TITLE
Apply loh_correction also to maf

### DIFF
--- a/RScripts/Main.R
+++ b/RScripts/Main.R
@@ -309,7 +309,6 @@ if (protocol == "somatic" | protocol == "somaticGermline") {
     snpefffile_snp = snpefffile_snp,
     snpefffile_indel = snpefffile_indel,
     outfile = filter_out_td,
-    outfile_maf = maf_td,
     path_data = path_data,
     path_script = path_script,
     mode = "T",
@@ -333,7 +332,6 @@ if (protocol == "somatic" | protocol == "somaticGermline") {
     snpefffile_snp = snpefffile_snp_loh,
     snpefffile_indel = snpefffile_indel_loh,
     outfile = loh_out,
-    outfile_maf = maf_loh,
     path_data = path_data,
     path_script = path_script,
     mode = "LOH",
@@ -358,7 +356,6 @@ if (protocol == "somatic" | protocol == "somaticGermline") {
       snpefffile_snp = snpefffile_snp_gd,
       snpefffile_indel = snpefffile_indel_gd,
       outfile =  filter_out_gd,
-      outfile_maf = maf_gd,
       path_data = path_data,
       path_script = path_script,
       mode = "N",
@@ -378,7 +375,8 @@ if (protocol == "somatic" | protocol == "somaticGermline") {
       filt_loh = filt_result_loh,
       filt_gd = filt_result_gd,
       protocol = protocol,
-      vaf = vaf
+      vaf = vaf,
+      actionable_genes = actionable_genes
     )
     filt_result_gd <- loh_correction$gd
     filt_result_loh <- loh_correction$loh
@@ -422,7 +420,6 @@ if (protocol == "panelTumor" | protocol == "tumorOnly") {
     snpefffile_snp = snpefffile_snp_td,
     snpefffile_indel = snpefffile_indel_td,
     outfile = filter_out_td,
-    outfile_maf = maf_td,
     path_data = path_data,
     path_script = path_script,
     mode = "T",
@@ -441,7 +438,6 @@ if (protocol == "panelTumor" | protocol == "tumorOnly") {
   filt_result_td_mutect2 <- filtering_mutect2(
     snpfile = mutect2_vcf,
     snpefffile = mutect2_snpEff_vcf,
-    outfile_maf = maf_td_mutect2,
     id = id,
     path_data = path_data,
     path_script = path_script,
@@ -508,6 +504,17 @@ if (protocol == "somaticGermline" | protocol == "somatic") {
         col.names = T,
         row.names = F
       )
+      if (nrow(filt_result_gd$maf) > 0) {
+        write.table(
+          x = maf_comb,
+          file = maf_gd,
+          append = F,
+          quote = F,
+          sep = "\t",
+          col.names = T,
+          row.names = F
+        )
+      }
   } else {
     maf_comb <- smartbind(
       filt_result_td$maf,
@@ -516,6 +523,28 @@ if (protocol == "somaticGermline" | protocol == "somatic") {
     write.table(
       x = maf_comb,
       file = maf_complete,
+      append = F,
+      quote = F,
+      sep = "\t",
+      col.names = T,
+      row.names = F
+    )
+  }
+  if (nrow(filt_result_td$maf) > 0) {
+    write.table(
+      x = maf_comb,
+      file = maf_td,
+      append = F,
+      quote = F,
+      sep = "\t",
+      col.names = T,
+      row.names = F
+    )
+  }
+    if (nrow(filt_result_loh$maf) > 0) {
+    write.table(
+      x = maf_comb,
+      file = maf_loh,
       append = F,
       quote = F,
       sep = "\t",

--- a/RScripts/Report_tools.R
+++ b/RScripts/Report_tools.R
@@ -1278,8 +1278,8 @@ pthws_mut <- function(df, protocol) {
   if (length(id_to) != 0) {
     df <- df[-c(id_to:dim(df)[1]), ]
   }
-  if (nrow(df) == 0 | class(df) == "list" | is.null(df)) {
-    if (nrow(df) == 0 | is.null(df)) {
+  if (is.null(df) || nrow(df) == 0 || class(df) == "list" || is.null(df)) {
+    if (is.null(df) || nrow(df) == 0) {
       return(NULL)
     } else if (sum(lapply(df, function(x){return(dim(x)[1])})) == 0){
       return(NULL)

--- a/RScripts/filtering.R
+++ b/RScripts/filtering.R
@@ -6,7 +6,6 @@ filtering <- function(
   snpefffile_snp,
   snpefffile_indel,
   outfile,
-  outfile_maf,
   path_data,
   path_script,
   mode = "T",
@@ -89,7 +88,7 @@ filtering <- function(
 
   # Filter for actionable genes in Germline
   if (protocol == "somaticGermline" & mode == "N") {
-    x <- actionable(x, actionable_genes)
+    x <- actionable(x, "Gene.refGene", actionable_genes)
   }
 
   # Quality Filter
@@ -252,15 +251,6 @@ filtering <- function(
       snv_vcf = snpefffile_snp,
       indel_vcf = snpefffile_indel
     )
-    write.table(
-      x = out.maf,
-      file = outfile_maf,
-      append = F,
-      quote = F,
-      sep = "\t",
-      col.names = T,
-      row.names = F
-    )
 
     return(
       list(
@@ -311,7 +301,6 @@ filtering_mutect2 <- function(
   snpfile,
   snpefffile,
   outfile,
-  outfile_maf,
   path_data,
   path_script,
   mode = "T",
@@ -526,15 +515,6 @@ filtering_mutect2 <- function(
       sep = "\t",
       idCol = NULL,
       Mutation_Status = mode
-    )
-    write.table(
-      x = out.maf,
-      file = outfile_maf,
-      append = F,
-      quote = F,
-      sep = "\t",
-      col.names = T,
-      row.names = F
     )
     
     return(


### PR DESCRIPTION
Right now the loh_correction is only applied to the table dataframe that is relevant for the results xlsx and the pdf report. The maf file for cBioPortal is unaffected.
This PR applies the same correction to the maf file. As LoHs might be moved to the germline dataframes it is necessary the apply the actionable_genes filter again.
This enforces to write the individual maf files to disk at a later time point.