### PR TITLE
fix possible knitr tex syntax issue

### DIFF
--- a/make_panel_report.sh
+++ b/make_panel_report.sh
@@ -81,6 +81,9 @@ ${BIN_RSCRIPT} "${DIR_RSCRIPT}/Main.R" "${CFG_CASE}" "${PARAM_DIR_PATIENT}" "${C
 # translate to tex
 ${BIN_RSCRIPT} --vanilla -e "load('${DIR_ANALYSES}/Report.RData'); library(knitr); knit('${DIR_RSCRIPT}/Report_Panel.Rnw');"
 
+# fix possible knitr syntax issues
+sed -i 's/\\textbf{.\\textbf{.}/\\textbf{.}/' ${DIR_ANALYSES}/Report.tex
+
 # PDF report
 mv "${DIR_ANALYSES}/Report_Panel.tex" "${DIR_ANALYSES}/${CFG_CASE}_${PARAM_DIR_PATIENT}_Report_Panel.tex"
 pdflatex -interaction=nonstopmode "${DIR_ANALYSES}/${CFG_CASE}_${PARAM_DIR_PATIENT}_Report_Panel.tex" \

--- a/make_report.sh
+++ b/make_report.sh
@@ -86,6 +86,9 @@ ${BIN_RSCRIPT} "${DIR_RSCRIPT}/Main.R" "${CFG_CASE}" "${PARAM_DIR_PATIENT}" "${C
 # translate to tex
 ${BIN_RSCRIPT} --vanilla -e "load('${DIR_ANALYSES}/Report.RData'); library(knitr); knit('${DIR_RSCRIPT}/Report.Rnw');"
 
+# fix possible knitr syntax issues
+sed -i 's/\\textbf{.\\textbf{.}/\\textbf{.}/' ${DIR_ANALYSES}/Report.tex
+
 # PDF report
 mv "${DIR_ANALYSES}/Report.tex" "${DIR_ANALYSES}/${CFG_CASE}_${PARAM_DIR_PATIENT}_Report.tex"
 pdflatex -interaction=nonstopmode "${DIR_ANALYSES}/${CFG_CASE}_${PARAM_DIR_PATIENT}_Report.tex" \

--- a/make_tumorOnly_report.sh
+++ b/make_tumorOnly_report.sh
@@ -81,6 +81,9 @@ ${BIN_RSCRIPT} "${DIR_RSCRIPT}/Main.R" "${CFG_CASE}" "${PARAM_DIR_PATIENT}" "${C
 # translate to tex
 ${BIN_RSCRIPT} --vanilla -e "load('${DIR_ANALYSES}/Report.RData'); library(knitr); knit('${DIR_RSCRIPT}/Report_tumorOnly.Rnw');"
 
+# fix possible knitr syntax issues
+sed -i 's/\\textbf{.\\textbf{.}/\\textbf{.}/' ${DIR_ANALYSES}/Report.tex
+
 # PDF report
 mv "${DIR_ANALYSES}/Report_tumorOnly.tex" "${DIR_ANALYSES}/${CFG_CASE}_${PARAM_DIR_PATIENT}_Report_tumorOnly.tex"
 pdflatex -interaction=nonstopmode "${DIR_ANALYSES}/${CFG_CASE}_${PARAM_DIR_PATIENT}_Report_tumorOnly.tex" \


### PR DESCRIPTION
Knitr sometimes produces syntactically *incorrect* tex files. This is usually with `\texbf{.}` that results in `\textbf{.\texbf{.}` this is more a workaround than a real fix but works just fine. 