### PR TITLE
fix compatiblity of ks.test() with R 4.2.0

### DIFF
--- a/RScripts/cnv_ana_tools.R
+++ b/RScripts/cnv_ana_tools.R
@@ -44,7 +44,7 @@ assess_significance <- function(ratio_file, cnvs_file) {
 
     KS <- function(values,normals){
       resultks <- try(ks.test(values, score(normals)), silent = TRUE)
-      if (class(resultks) == "try-error") {
+      if (inherits(class(resultks), "try-error")) {
         return(list("statistic" = NA, "p.value" = NA, "alternative" = NA,
                     "method" = NA, "data.name" = NA))
       } else {


### PR DESCRIPTION
R 4.2.0 is not very happy about the check for errors in the `ks.test()`:

```
Error in if (class(resultks) == "try-error") { : 
  the condition has length > 1
```

According to the changelog the function `inherits()` should be used.