### PR TITLE
fix genome refBuild

### DIFF
--- a/RScripts/filtering.R
+++ b/RScripts/filtering.R
@@ -510,7 +510,7 @@ filtering_mutect2 <- function(
       protocol = protocol,
       snv_vcf = snpefffile,
       Center = center,
-      refBuild = 'hg19',
+      refBuild = 'GRCh37',
       id = sample,
       sep = "\t",
       idCol = NULL,


### PR DESCRIPTION
All other filtering functions use the GRCh37 value for refBuild. This actually prevents importing tumorOnly/panel data and somatic(Germline) data into the same study.