### PR TITLE
fix gatk vaf percent

### DIFF
--- a/RScripts/Report_tools.R
+++ b/RScripts/Report_tools.R
@@ -676,9 +676,6 @@ highlight <- function(muts_tab, protocol) {
 
     # VAF
     highlight$VAF <- gsub(pattern = "%", replacement = "", x = highlight$VAF)
-    if (protocol == "panelTumor" | protocol == "tumorOnly") {
-      highlight$VAF <- as.numeric(highlight$VAF)*100
-    }
 
     # InterVar (ACMG)
     highlight$Classification <- acmg(df = highlight)[, 2]
@@ -817,9 +814,6 @@ highlight_detail <- function(muts_tab, Mode = "Tumor", protocol) {
         pattern = "%", replacement = "",
         x = highlight$Variant_Allele_Frequency
       )
-      if (protocol == "panelTumor" | protocol == "tumorOnly") {
-        highlight$VAF <- as.numeric(highlight$VAF)*100
-      }
       highlight$VAF <- paste0(
         highlight$VAF, " (", highlight$Variant_Reads, ")"
       )
@@ -1389,9 +1383,6 @@ pthws_mut <- function(df, protocol) {
     df$VAF <- gsub(
       pattern = "%", replacement = "", x = df$VAF, fixed = TRUE
     )
-    if (protocol == "panelTumor" | protocol == "tumorOnly") {
-      df$VAF <- as.numeric(df$VAF)*100
-    }
     df$VAF <- paste0(df$VAF, " (", df$Reads, ")")
     # AAChange
     df$AAChange <- gsub(
@@ -1481,9 +1472,7 @@ topart_mut <- function(df, protocol) {
     )
     # VAF
     df$VAF <- gsub(pattern = "%", replacement = "", x = df$VAF, fixed = TRUE)
-    if (protocol == "panelTumor" | protocol == "tumorOnly") {
-      df$VAF <- as.numeric(df$VAF)*100
-    }
+
     df$VAF <- paste0(df$VAF, " (", df$Reads, ")")
     # AAChange
     df$AAChange <- gsub(

--- a/RScripts/filtering.R
+++ b/RScripts/filtering.R
@@ -389,8 +389,10 @@ filtering_mutect2 <- function(
   # Extract VAF, Readcounts (and Zygosity)
   x <- vrz_gatk(x = x, mode = mode, protocol = protocol)
   
+  x <- normalize_vaf_gatk(x = x)
+
   # VAF Filter
-  x <- exclude_gatk(x, vaf = vaf/100)
+  x <- exclude(x, vaf = vaf)
   
   # Remove Variants with Variant Read Count below 4/20
   x <- mrc(x = x, min_var_count = min_var_count)

--- a/RScripts/filtering_tools.R
+++ b/RScripts/filtering_tools.R
@@ -1613,11 +1613,9 @@ exclude <- function(x, vaf = 5){
   return(x)
 }
 
-exclude_gatk <- function(x, vaf = 0.05){
-  id <- which(as.numeric(x$Variant_Allele_Frequency) >= vaf)
-  if(length(id) > 0) {
-    x <- x[id, ]
-  }
+normalize_vaf_gatk <- function(x){
+  x$Variant_Allele_Frequency <- as.numeric(x$Variant_Allele_Frequency) * 100
+  x$Variant_Allele_Frequency <- paste0(x$Variant_Allele_Frequency, "%")
   return(x)
 }
 


### PR DESCRIPTION
Right now varscan outputs the vaf das "12.34%" while gatk would write "0.1234". This was addressed for the pdf report but not the exported xlsx file. Now they look exactly the same.