### PR TITLE
error when building docker images

### DIFF
--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -33,7 +33,7 @@ function install_R()
   echo "deb http://cloud.r-project.org/bin/linux/debian buster-cran40/" >> /etc/apt/sources.list && \
   apt-key add "/opt/MIRACUM-Pipe/debian/r_key.asc"
   #apt-key adv --keyserver keyserver.ubuntu.com --recv-key B8F25A8A73EACF41
-  apt-get update && apt-get install -y --no-install-recommends r-base-dev=3.5.2-1
+  apt-get update && apt-get install -y --no-install-recommends -t buster-cran40 r-base-dev
   R CMD javareconf
 }
 

--- a/debian/setup.sh
+++ b/debian/setup.sh
@@ -33,7 +33,7 @@ function install_R()
   echo "deb http://cloud.r-project.org/bin/linux/debian buster-cran40/" >> /etc/apt/sources.list && \
   apt-key add "/opt/MIRACUM-Pipe/debian/r_key.asc"
   #apt-key adv --keyserver keyserver.ubuntu.com --recv-key B8F25A8A73EACF41
-  apt-get update && apt-get install -y --no-install-recommends -t buster-cran40 r-base-dev
+  apt-get update && apt-get install -y --no-install-recommends r-base-dev=3.5.2-1
   R CMD javareconf
 }
 
@@ -60,5 +60,5 @@ apt-get install -y --no-install-recommends build-essential gcc-multilib libc-dev
   install_R && \
   install_texlive && \
   python3 -m pip install wheel && \
-  python3 -m pip install shyaml agfusion sequenza-utils && \
+  python3 -m pip install shyaml agfusion==1.4.1 pyensembl==2.2.9 gtfparse==1.3.0 sequenza-utils && \
   apt-get -y autoremove


### PR DESCRIPTION
I am running in several errors when try building the different docker images.

At first, the installation of pip packages fails:
```
$ ./build base
...
161.2 Collecting pyarrow<14.1.0,>=14.0.2 (from gtfparse<3.0.0,>=2.5.0->pyensembl>=1.1.0->agfusion)
161.5   Could not find a version that satisfies the requirement pyarrow<14.1.0,>=14.0.2 (from gtfparse<3.0.0,>=2.5.0->pyensembl>=1.1.0->agfusion) (from versions: 0.9.0, 0.10.0, 0.11.0, 0.11.1, 0.12.0, 0.12.1, 0.13.0, 0.14.0, 0.14.1, 0.15.0, 0.15.1, 0.16.0, 0.17.0, 0.17.1, 1.0.0, 1.0.1, 2.0.0, 3.0.0, 4.0.0, 4.0.1, 5.0.0, 6.0.0, 6.0.1, 7.0.0, 8.0.0, 9.0.0, 10.0.0, 10.0.1, 11.0.0, 12.0.0, 12.0.1)
161.5 No matching distribution found for pyarrow<14.1.0,>=14.0.2 (from gtfparse<3.0.0,>=2.5.0->pyensembl>=1.1.0->agfusion)
------
Dockerfile_base:8
--------------------
   7 |
   8 | >>> RUN apt-get update && \
   9 | >>>     apt-get install -y --no-install-recommends apt-utils && \
  10 | >>>     apt-get upgrade -y && \
  11 | >>>     /opt/MIRACUM-Pipe/debian/setup.sh
  12 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends apt-utils &&     apt-get upgrade -y &&     /opt/MIRACUM-Pipe/debian/setup.sh" did not complete successfully: exit code: 1
```

I add versions for the pip packages. Then the build process works.

Unfortunately, in addition i realized that the package `cnvkit` is not available in container. It seems that the problem is, that this package depends on `r-api-3.5 `. The build process installs `cnvkit`:
```
...
#7 43.87 Selecting previously unselected package cnvkit.
#7 43.87 Preparing to unpack .../170-cnvkit_0.9.5-3_amd64.deb ...
#7 43.87 Unpacking cnvkit (0.9.5-3) ...
...
#7 96.32 Setting up cnvkit (0.9.5-3) ...
...
```

but later it is deinstalled because the function `install_R()` in https://github.com/alexanderscholz/MIRACUM-Pipe/blob/master/debian/setup.sh#L31 installs R version 4 and cvnkit is not compatible with this version.
```shell
...
#7 125.6 The following packages will be REMOVED:
#7 125.6   cnvkit pkg-config r-bioc-dnacopy
#7 125.6 The following NEW packages will be installed:
#7 125.6   libblas-dev libdeflate-dev liblapack-dev libpcre2-16-0 libpcre2-32-0
#7 125.7   libpcre2-dev libpcre2-posix0 libreadline-dev libtirpc-common libtirpc-dev
#7 125.7   libtirpc3 libxmuu1 pkgconf r-base-dev xauth
#7 125.7 The following packages will be upgraded:
#7 125.7   r-base-core
...
```

I tried to install and older version with
```
apt-get update && apt-get install -y --no-install-recommends r-base-dev=3.5.2-1
```

in https://github.com/alexanderscholz/MIRACUM-Pipe/blob/master/debian/setup.sh#L36 but this brings new problems when building the R image.

I also tried to install `cnvkit` with pip3 but i had problems to install the dependency `scikit-learn`. Don't know why at the moment. Maybe you have an idea?